### PR TITLE
Update ca-certificates and pip version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN apk -U add \
         curl ca-certificates \
     && update-ca-certificates \
     && rm -rf /var/cache/apk/* \
+    && pip install --upgrade pip \
     && pip install Scrapy
 
 WORKDIR /runtime/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ RUN apk -U add \
         python-dev \
         py-imaging \
         py-pip \
+        curl ca-certificates \
+    && update-ca-certificates \
     && rm -rf /var/cache/apk/* \
     && pip install Scrapy
 


### PR DESCRIPTION
* The ca-certificates update prevents the following error when installing Twisted:

Download error on https://pypi.python.org/simple/incremental/: [SSL:CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:661) -- Some packages may not be found!

* The pip upgrade prevents a warning message during installation 