### PR TITLE
upgrade to python 3 and replace libopenssl with libressl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
 FROM alpine:latest
 
 RUN apk -U add \
+        python3 \
         gcc \
         libffi-dev \
         libxml2-dev \
         libxslt-dev \
         musl-dev \
-        openssl-dev \
+        libressl-dev \
         python-dev \
         py-imaging \
         py-pip \


### PR DESCRIPTION
# Goal of this pull request

Support for python 2.7 will be EOLd 1/1/2020.  Additionally due to Alpine package pinning (or lackthereof) some other external dependencies that a project using this as the base image for are not being friendly with openssl and instead rely on the fully compatible libressl (pycopglib is a good example).

This pull request installs python 3 and changes the use of libopenssl to libressl.  