### PR TITLE
Remove libressl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ RUN apk -U add \
         libxml2-dev \
         libxslt-dev \
         openssl-dev \
-        libressl-dev \
         python3-dev \
         py-pip \
         curl \


### PR DESCRIPTION
openssl and libressl can not be installed together and will result in errors during installation when you do. Removing the latter since Python 3.10 dropped support for it.